### PR TITLE
Add force flag to symbolic link

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,4 @@
 echo "Update theme scheme"
 cp templates/colors-vscode-theme.json ~/.config/wal/templates/
 mkdir -p themes
-ln -s ~/.cache/wal/colors-vscode-theme.json themes/vs-wal-color-theme.json
+ln -sf ~/.cache/wal/colors-vscode-theme.json themes/vs-wal-color-theme.json


### PR DESCRIPTION
The -sf flag is necessary for overwriting the existing link.