### PR TITLE
Update template to only reference wal color palette

### DIFF
--- a/templates/colors-vscode-theme.json
+++ b/templates/colors-vscode-theme.json
@@ -38,8 +38,8 @@
 		"statusBar.noFolderForeground": "{foreground}",
 		"statusBar.noFolderBackground": "{background}",
 		"statusBar.foreground": "{foreground}",
-		"tab.activeBorder": "#88c0d000",
-		"tab.unfocusedActiveBorder": "#88c0d000",
+		"tab.activeBorder": "{color0}",
+		"tab.unfocusedActiveBorder": "{color0}",
 		"tab.activeBackground": "{foreground}10",
 		"tab.activeForeground": "{foreground}",
 		"tab.inactiveBackground": "{background}",
@@ -95,7 +95,7 @@
 				"constant.other.color"
 			],
 			"settings": {{
-				"foreground": "#ffffff"
+				"foreground": "{color7}"
 			}}
 		}},
 		{{
@@ -105,7 +105,7 @@
 				"invalid.illegal"
 			],
 			"settings": {{
-				"foreground": "#FF5370"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -147,7 +147,7 @@
 				"markup.deleted.git_gutter"
 			],
 			"settings": {{
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -169,7 +169,7 @@
 				"meta.block variable.other"
 			],
 			"settings": {{
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -179,7 +179,7 @@
 				"string.other.link"
 			],
 			"settings": {{
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -236,7 +236,7 @@
 				"support.type"
 			],
 			"settings": {{
-				"foreground": "#B2CCD6"
+				"foreground": "{color14}"
 			}}
 		}},
 		{{
@@ -250,7 +250,7 @@
 				"source.postcss support.type.property-name"
 			],
 			"settings": {{
-				"foreground": "#B2CCD6"
+				"foreground": "{color14}"
 			}}
 		}},
 		{{
@@ -261,7 +261,7 @@
 				"variable.other.class.js"
 			],
 			"settings": {{
-				"foreground": "#FF5370"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -271,7 +271,7 @@
 			],
 			"settings": {{
 				"fontStyle": "italic",
-				"foreground": "#FF5370"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -281,7 +281,7 @@
 			],
 			"settings": {{
 				"fontStyle": "italic",
-				"foreground": "#82AAFF"
+				"foreground": "{color12}"
 			}}
 		}},
 		{{
@@ -291,7 +291,7 @@
 				"variable.function.constructor"
 			],
 			"settings": {{
-				"foreground": "#82AAFF"
+				"foreground": "{color12}"
 			}}
 		}},
 		{{
@@ -300,7 +300,7 @@
 				"entity.other.attribute-name"
 			],
 			"settings": {{
-				"foreground": "#C792EA"
+				"foreground": "{color13}"
 			}}
 		}},
 		{{
@@ -311,7 +311,7 @@
 			],
 			"settings": {{
 				"fontStyle": "italic",
-				"foreground": "#FFCB6B"
+				"foreground": "{color3}"
 			}}
 		}},
 		{{
@@ -320,7 +320,7 @@
 				"entity.other.attribute-name.class"
 			],
 			"settings": {{
-				"foreground": "#FFCB6B"
+				"foreground": "{color3}"
 			}}
 		}},
 		{{
@@ -329,7 +329,7 @@
 				"source.sass keyword.control"
 			],
 			"settings": {{
-				"foreground": "#82AAFF"
+				"foreground": "{color12}"
 			}}
 		}},
 		{{
@@ -338,7 +338,7 @@
 				"markup.inserted"
 			],
 			"settings": {{
-				"foreground": "#C3E88D"
+				"foreground": "{color10}"
 			}}
 		}},
 		{{
@@ -347,7 +347,7 @@
 				"markup.deleted"
 			],
 			"settings": {{
-				"foreground": "#FF5370"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -356,7 +356,7 @@
 				"markup.changed"
 			],
 			"settings": {{
-				"foreground": "#C792EA"
+				"foreground": "{color13}"
 			}}
 		}},
 		{{
@@ -365,7 +365,7 @@
 				"string.regexp"
 			],
 			"settings": {{
-				"foreground": "#89DDFF"
+				"foreground": "{color14}"
 			}}
 		}},
 		{{
@@ -374,7 +374,7 @@
 				"constant.character.escape"
 			],
 			"settings": {{
-				"foreground": "#89DDFF"
+				"foreground": "{color14}"
 			}}
 		}},
 		{{
@@ -396,7 +396,7 @@
 			],
 			"settings": {{
 				"fontStyle": "italic",
-				"foreground": "#82AAFF"
+				"foreground": "{color12}"
 			}}
 		}},
 		{{
@@ -406,7 +406,7 @@
 			],
 			"settings": {{
 				"fontStyle": "italic",
-				"foreground": "#FF5370"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -442,7 +442,7 @@
 				"source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
 			],
 			"settings": {{
-				"foreground": "#FF5370"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -451,7 +451,7 @@
 				"source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
 			],
 			"settings": {{
-				"foreground": "#C17E70"
+				"foreground": "{color10}"
 			}}
 		}},
 		{{
@@ -460,7 +460,7 @@
 				"source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
 			],
 			"settings": {{
-				"foreground": "#82AAFF"
+				"foreground": "{color12}"
 			}}
 		}},
 		{{
@@ -469,7 +469,7 @@
 				"source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
 			],
 			"settings": {{
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -478,7 +478,7 @@
 				"source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
 			],
 			"settings": {{
-				"foreground": "#C792EA"
+				"foreground": "{color13}"
 			}}
 		}},
 		{{
@@ -487,7 +487,7 @@
 				"source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
 			],
 			"settings": {{
-				"foreground": "#C3E88D"
+				"foreground": "{color10}"
 			}}
 		}},
 		{{
@@ -497,7 +497,7 @@
 				"punctuation.definition.list_item.markdown"
 			],
 			"settings": {{
-				"foreground": "#EEFFFF"
+				"foreground": "{color7}"
 			}}
 		}},
 		{{
@@ -506,7 +506,7 @@
 				"text.html.markdown markup.inline.raw.markdown"
 			],
 			"settings": {{
-				"foreground": "#C792EA"
+				"foreground": "{color13}"
 			}}
 		}},
 		{{
@@ -515,7 +515,7 @@
 				"text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
 			],
 			"settings": {{
-				"foreground": "#65737E"
+				"foreground": "{color8}"
 			}}
 		}},
 		{{
@@ -535,7 +535,7 @@
 				"markup.heading.markdown punctuation.definition.heading.markdown"
 			],
 			"settings": {{
-				"foreground": "#C3E88D"
+				"foreground": "{color10}"
 			}}
 		}},
 		{{
@@ -545,7 +545,7 @@
 			],
 			"settings": {{
 				"fontStyle": "italic",
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -556,7 +556,7 @@
 			],
 			"settings": {{
 				"fontStyle": "bold",
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -571,7 +571,7 @@
 			],
 			"settings": {{
 				"fontStyle": "bold",
-				"foreground": "#f07178"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
@@ -581,7 +581,7 @@
 			],
 			"settings": {{
 				"fontStyle": "underline",
-				"foreground": "#F78C6C"
+				"foreground": "{color10}"
 			}}
 		}},
 		{{
@@ -600,8 +600,8 @@
 				"markup.quote punctuation.definition.blockquote.markdown"
 			],
 			"settings": {{
-				"background": "#65737E",
-				"foreground": "#65737E"
+				"background": "{color8}",
+				"foreground": "{color8}"
 			}}
 		}},
 		{{
@@ -620,7 +620,7 @@
 				"string.other.link.title.markdown"
 			],
 			"settings": {{
-				"foreground": "#82AAFF"
+				"foreground": "{color12}"
 			}}
 		}},
 		{{
@@ -629,7 +629,7 @@
 				"string.other.link.description.title.markdown"
 			],
 			"settings": {{
-				"foreground": "#C792EA"
+				"foreground": "{color13}"
 			}}
 		}},
 		{{
@@ -638,7 +638,7 @@
 				"constant.other.reference.link.markdown"
 			],
 			"settings": {{
-				"foreground": "#FFCB6B"
+				"foreground": "{color3}"
 			}}
 		}},
 		{{
@@ -647,7 +647,7 @@
 				"markup.raw.block"
 			],
 			"settings": {{
-				"foreground": "#C792EA"
+				"foreground": "{color13}"
 			}}
 		}},
 		{{
@@ -656,7 +656,7 @@
 				"markup.raw.block.fenced.markdown"
 			],
 			"settings": {{
-				"foreground": "#00000050"
+				"foreground": "{color15}50"
 			}}
 		}},
 		{{
@@ -665,7 +665,7 @@
 				"punctuation.definition.fenced.markdown"
 			],
 			"settings": {{
-				"foreground": "#00000050"
+				"foreground": "{color15}50"
 			}}
 		}},
 		{{
@@ -676,7 +676,7 @@
 				"punctuation.section.class.end"
 			],
 			"settings": {{
-				"foreground": "#EEFFFF"
+				"foreground": "{color7}"
 			}}
 		}},
 		{{
@@ -685,7 +685,7 @@
 				"variable.language.fenced.markdown"
 			],
 			"settings": {{
-				"foreground": "#65737E"
+				"foreground": "{color8}"
 			}}
 		}},
 		{{
@@ -695,8 +695,8 @@
 			],
 			"settings": {{
 				"fontStyle": "bold",
-				"background": "#00000050",
-				"foreground": "#65737E"
+				"background": "{color15}50",
+				"foreground": "{color8}"
 			}}
 		}},
 		{{
@@ -705,31 +705,31 @@
 				"markup.table"
 			],
 			"settings": {{
-				"foreground": "#EEFFFF"
+				"foreground": "{color7}"
 			}}
 		}},
 		{{
 			"scope": "token.info-token",
 			"settings": {{
-				"foreground": "#6796e6"
+				"foreground": "{color6}"
 			}}
 		}},
 		{{
 			"scope": "token.warn-token",
 			"settings": {{
-				"foreground": "#cd9731"
+				"foreground": "{color3}"
 			}}
 		}},
 		{{
 			"scope": "token.error-token",
 			"settings": {{
-				"foreground": "#f44747"
+				"foreground": "{color9}"
 			}}
 		}},
 		{{
 			"scope": "token.debug-token",
 			"settings": {{
-				"foreground": "#b267e6"
+				"foreground": "{color13}"
 			}}
 		}}
 	]


### PR DESCRIPTION
This is in reference to Issue #5, all of the colors that were referenced by hex codes (e.g. #FFFFFF) were changed to reference a color from the wal color palette (e.g. {color7}), making it more usable for light theme.